### PR TITLE
Link more RecordIO things

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | ColumnIO / [Capacitor](https://cloud.google.com/blog/big-data/2016/04/inside-capacitor-bigquerys-next-generation-columnar-storage-format) |                                          | [Apache Parquet](http://parquet.apache.org) |
 | sstable                                  | [levelDB](https://github.com/google/leveldb) | [RocksDB](https://rocksdb.org), [pebble](https://github.com/cockroachdb/pebble)      |
 | zippy                                    | [Snappy](https://github.com/google/snappy) | [lz4](https://github.com/lz4/lz4)        |
-| RecordIO                                 | [TFRecords](https://github.com/tensorflow/docs/blob/r1.10/site/en/api_guides/python/python_io.md#tfrecords-format-details) | |
+| RecordIO                                 | [Riegeli](https://github.com/google/riegeli), [TFRecords](https://github.com/tensorflow/docs/blob/r1.10/site/en/api_guides/python/python_io.md#tfrecords-format-details), & in [OR-Tools](https://github.com/google/or-tools/blob/stable/ortools/base/recordio.h), [szl](https://github.com/google/szl/blob/master/src/utilities/recordio.cc) | [stuffed-record-stream](https://github.com/backtrace-labs/stuffed-record-stream) |
 
 
 ### Services


### PR DESCRIPTION
Link things from Google that are called "recordio" (inside or-tools and szl).

Link Riegeli and stuffed-record-stream because they do something similar to
the things from Google that are called "recordio".

These are all similar to the already-linked "TFRecords".