### PR TITLE
Add Linter and Mergequeue to DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | [DiRT](https://cloud.google.com/blog/products/management-tools/shrinking-the-time-to-mitigate-production-incidents) | | [ChaosMonkey](https://github.com/Netflix/chaosmonkey), [aws fis](https://aws.amazon.com/fis/) |
 | [Rosie](https://cacm.acm.org/magazines/2016/7/204032-why-google-stores-billions-of-lines-of-code-in-a-single-repository/fulltext) | | [microplane](https://github.com/Clever/microplane), [silver-platter](https://github.com/jelmer/silver-platter) |
 | API Improvements Proposals | [AIP](https://google.aip.dev/) | |
+| g4 {fix, submit} | | [Trunk.io](https://trunk.io) |
 
 ### Security
 | Google Internal                  | Google External | Open Source                              |


### PR DESCRIPTION
I started missing some of the cross language linters / formatters, as well as the MergeQueue when submitting code. I added the tools (g4 fix, submit) that I frequently used and one solution to them.