### PR TITLE
Add tailscale's golink tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | stuff (Device Management)                | [Fleetsmith](https://www.fleetsmith.com/), [jamf](https://www.jamf.com/) |
 | device security monitoring               | [Red Canary](https://redcanary.com/) |
 | beyondcorp | [beyondcorp](https://www.beyondcorp.com/) |
-| [go/ links](https://medium.com/@golinks/the-full-history-of-go-links-and-the-golink-system-cbc6d2c8bb3)                                | [golinks](https://www.golinks.io/), [go](https://github.com/kellegous/go), [Goat](https://goatcodes.com/), [trotto](https://github.com/trotto/go-links), [go-shorten](https://github.com/thomasdesr/go-shorten) |
+| [go/ links](https://medium.com/@golinks/the-full-history-of-go-links-and-the-golink-system-cbc6d2c8bb3)                                | [golink](https://github.com/tailscale/golink), [golinks](https://www.golinks.io/), [go](https://github.com/kellegous/go), [Goat](https://goatcodes.com/), [trotto](https://github.com/trotto/go-links), [go-shorten](https://github.com/thomasdesr/go-shorten) |
 | google3 philosophy                       | [innersource](https://resources.github.com/whitepapers/introduction-to-innersource/), [monorepo](https://cacm.acm.org/magazines/2016/7/204032-why-google-stores-billions-of-lines-of-code-in-a-single-repository/fulltext) |
 | doing code review                        | [code review](https://google.github.io/eng-practices/review/reviewer/) |
 | safely sharing 1-time secrets            | [sendsecure.ly](sendsecure.ly), [croc](https://github.com/schollz/croc), [onetimesecret](https://github.com/onetimesecret/onetimesecret), [privatebin](https://privatebin.info/) |


### PR DESCRIPTION
I tried a few go link tools, but tailscale's golink tool perfectly captures the original golink spirit with a minimal tool that works well (especially over tailscale since you don't have to bother with https, which means you can literally type `go/something` in your browsers without having to use any pesky extension!