### PR TITLE
Create Development & Observability Sections, Refactor DevOps section, Subdivide Problemspaces for Clarify, Add more Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | Borg                 | [Kubernetes](https://kubernetes.io/)     | [Apache Mesos](https://github.com/apache/mesos), [Apache Aurora](https://aurora.apache.org/), [HashiCorp Nomad](https://github.com/hashicorp/nomad) |
 | GSLB | [Cloud Load Balancing](https://cloud.google.com/load-balancing) - Internal | AWS ELB,  [Istio](https://istio.io/), [linkerd](https://linkerd.io/)
 | OnePlatform          | [API Gateway](https://cloud.google.com/api-gateway) | [Swagger](https://swagger.io/) |
-| GFE, Maglev, uberproxy | [Cloud Load Balancing](https://cloud.google.com/load-balancing) - HTTPS / External | [envoy](https://www.envoyproxy.io/), AWS ALB, [HAProxy](https://www.haproxy.org/), [nginx](https://www.nginx.com/), [F5](https://f5.com/products/big-ip) |
+| GFE | [Cloud Load Balancing](https://cloud.google.com/load-balancing) - HTTPS / External | [envoy](https://www.envoyproxy.io/), AWS ALB, [HAProxy](https://www.haproxy.org/), [nginx](https://www.nginx.com/), [F5](https://f5.com/products/big-ip) |
+| Maglev, USPS  | [Cloud Load Balancing](https://cloud.google.com/load-balancing) - [NEGs](https://cloud.google.com/load-balancing/docs/negs) | [Cilium](https://cilium.io/), [MetalLB](https://metallb.io/) |
 | uberproxy (sso proxy) | [Identity-Aware Proxy](https://cloud.google.com/iap) | [buzzfeed-sso](https://github.com/buzzfeed/sso), [Pomerium](https://pomerium.io/), [Envoy Gateway](https://gateway.envoyproxy.io/docs/tasks/security/oidc/) |
 | Zanzibar             | [Zanzibar Research Paper](https://research.google/pubs/pub48190/) | [SpiceDB](https://github.com/authzed/spicedb)/[authzed](https://authzed.com/), [Ory Keto](https://www.ory.sh/keto/docs/), [topaz](https://github.com/aserto-dev/topaz), [Opal](https://opal.dev/), [(iam)Keycloak](https://www.keycloak.org/), [Warrant](https://github.com/warrant-dev/warrant), [OpenFGA](https://openfga.dev/) |
 | data center hardware | [open compute](https://www.opencompute.org/) |                                          |
 | Jupiter, Starblaze   |                                          |                                             |
 | B4, Stargate, TE     |                                          |                                             |
-| USPS, Andromeda      |                                          |                                             |
 | ESDN                 |                                          | [Faucet](https://github.com/faucetsdn/faucet)
 | [broccoli man](https://www.youtube.com/watch?v=3t6L-FlfeaI)  | ||
 
@@ -57,55 +57,72 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | Dremel                                   | [BigQuery](https://cloud.google.com/bigquery/) | [Apache Drill](https://github.com/apache/drill), [Presto](https://prestodb.io), Spark(sort-of), | [AWS Athena](https://aws.amazon.com/athena/), [Redshift Spectrum](https://aws.amazon.com/redshift/spectrum/), [Snowflake](https://www.snowflake.com) |
 | Dremel UI                                |                                          | [Redash](https://github.com/getredash/redash), [Metabase](https://github.com/metabase/metabase), [Apache Superset](https://github.com/apache/incubator-superset) |                                          |
 | Search (Mustang, Alexandria)             |                                          | [Elasticsearch](https://github.com/elastic/elasticsearch), [OpenSearch](https://opensearch.org/), Solr, Lucene              | [algolia](https://www.algolia.com/)      |
-| pubsub                                   | [pubsub](https://cloud.google.com/pubsub/docs/overview) | [NATS.io](https://nats.io), [RabbitMQ](https://github.com/rabbitmq), [PubNub](https://www.pubnub.com/) | AWS SQS/SNS, [AWS AppSync](https://aws.amazon.com/appsync) |
+| PubSub                                   | [pubsub](https://cloud.google.com/pubsub/docs/overview) | [NATS.io](https://nats.io), [RabbitMQ](https://github.com/rabbitmq), [PubNub](https://www.pubnub.com/) | AWS SQS/SNS, [AWS AppSync](https://aws.amazon.com/appsync) |
 | [MillWheel](https://ai.google/research/pubs/pub41378) | [Cloud Dataflow](https://cloud.google.com/dataflow/) | [Apache Flink](https://flink.apache.org/), beam |                |
 | Colab | [Colaboratory](https://colab.research.google.com/) | [Jupyter](https://jupyter.org) | [Observable](https://observablehq.com/) |
 | PLX | [Google Data Studio](https://datastudio.google.com/) | | [Mode](https://mode.com) |
-| Monarch | [paper](https://research.google/pubs/pub50652/) | | |
 | Napa | [paper](https://research.google/pubs/pub50617/) | | |
 | MakerSuite| [MakerSuite](https://makersuite.google.com) | | |
 
+### Development, Build System
 
-### DevOps
+| Google Internal                 | Google External                          | Real-World                               |
+| ------------------------------- | ---------------------------------------- | ---------------------------------------- |
+| Blaze                           | [Bazel](https://bazel.build)             | [Buck](https://buckbuild.com/), [Pants](https://www.pantsbuild.org/), [please.build](https://please.build/), [Blade](https://github.com/chen3feng/blade-build), [recc](https://gitlab.com/bloomberg/recc), [EngFlow](https://www.engflow.com/), [BuildBuddy](https://www.buildbuddy.io/), [flare.build](https://flare.build) |
+| Sponge                          |                                          | [EngFlow](https://www.engflow.com/) |
+| Blaze/TAP/BuildCop        | [Cloud Build](https://cloud.google.com/cloud-build/) | [buildkite](https://buildkite.com/), [CircleCI](https://circleci.com), [Drone](https://drone.io/), [EngFlow](https://www.engflow.com/), [github](https://github.blog/2019-08-08-github-actions-now-supports-ci-cd/), [gitlabCI](https://about.gitlab.com/product/continuous-integration/), [jenkins](https://jenkins.io/), [travis](https://travis-ci.org/) |
+| Forge/ObjFS                     |                                          | [EngFlow](https://www.engflow.com/), [flare.build](https://flare.build) |
+| Sandman(test env)/Guitar        |                                          |                   |
+| cider                           |  [Firebase Studio](https://firebase.studio/) neé IDX   | [Eclipse Che](https://www.eclipse.org/che/), [Cloud9](https://c9.io/), [gitpod.io](https://gitpod.io), [Coder](https://coder.com/), [Code-Server (VSCode in a Tab)](https://github.com/cdr/code-server), [DevZero](https://www.devzero.io/) |
+| CodeSearch, Grimoire            | [Zoekt](https://github.com/google/zoekt) [kythe](https://github.com/kythe/kythe) [Code Search](https://developers.google.com/code-search/user/getting-started) (for Google open source code only, with separate UI for Android and Chromium. Go CLI [source](https://github.com/google/codesearch).) | [Sourcegraph](https://sourcegraph.com), [OpenGrok](https://github.com/OpenGrok/OpenGrok/), [livegrep](https://github.com/livegrep/livegrep), [Sourcebot](https://www.sourcebot.dev) |
+| Critique, Gerrit, Mondrian etc. | [Gerrit](https://www.gerritcodereview.com/) | [Reviewable](https://reviewable.io) , [Phabricator](https://www.phacility.com/phabricator/)     |
+| styleguides                     | [google styleguides](https://github.com/google/styleguide) | [PEP-8](https://www.python.org/dev/peps/pep-0008/), [HoundCI auto-style-reviewer](https://houndci.com/) |
+| [Rosie](https://cacm.acm.org/magazines/2016/7/204032-why-google-stores-billions-of-lines-of-code-in-a-single-repository/fulltext) | | [microplane](https://github.com/Clever/microplane), [silver-platter](https://github.com/jelmer/silver-platter) |
+| g4 {fix, submit} | | [Trunk.io](https://trunk.io), [Graphite](https://graphite.dev/) |
+| C++ Tips of the Week            | [Abseil C++ Tips of the Week](https://abseil.io/tips/) |  |
+| ToTT                            | [Google Test Blog](https://testing.googleblog.com/) | [Increment](https://increment.com/) |
+
+
+
+### SRE/DevOps - Observability
+| Google Internal                 | Google External                          | Real-World                               |
+| ------------------------------- | ---------------------------------------- | ---------------------------------------- |
+| Varz                          |                                          | [OpenMetrics](https://www.openmetrics.io) |
+| Borgmon            | Google Managed Prometheus | [Datadog](https://www.datadoghq.com/), [Prometheus](https://prometheus.io), [M3](https://m3db.io/), [librato](https://www.librato.com), [newrelic](https://newrelic.com), skylight, scout, [Scotty](https://github.com/Cloud-Foundations/scotty)/[tricorder](https://github.com/Cloud-Foundations/tricorder), [netdata](https://github.com/netdata/netdata), [bosun](https://bosun.org/), also [this](https://vimeo.com/173610242) and [this](https://prometheus.io/docs/introduction/comparison/) |
+| SVS, Bartlett            |  | [prometheus/node_exporter](https://www.github.com/prometheus/node_exporter) |
+| [Monarch](https://research.google/pubs/pub50652/)            | [Cloud Monitoring](https://cloud.google.com/monitoring) | [Datadog](https://www.datadoghq.com/), [librato](https://www.librato.com), [newrelic](https://newrelic.com), skylight, scout, [Scotty](https://github.com/Cloud-Foundations/scotty)/[tricorder](https://github.com/Cloud-Foundations/tricorder), [netdata](https://github.com/netdata/netdata), [bosun](https://bosun.org/) ) |
+| Viceroy                         | Cloud Monitoring                         | [Grafana](https://grafana.com/) |
+| Exception/Error Tracking (thirdeye)   |                                          | Sentry.io, Raygun.io, [Rollbar](https://rollbar.com), Honeybadger, Airbrake, OverOps, [ELK stack](https://www.elastic.co/what-is/elk-stack) |
+| [Dapper](https://ai.google/research/pubs/pub36356) | [stackdriver trace](https://cloud.google.com/trace/) | [zipkin](https://github.com/openzipkin/zipkin), [OpenTelemetry](https://opentelemetry.io/), [jaeger](https://www.jaegertracing.io/), [LightStep](https://lightstep.com), [Honeycomb](https://www.honeycomb.io/trace/) |
+| logging, analog                 | [StackDriver](https://cloud.google.com/stackdriver/) | [logstash](https://github.com/elastic/logstash), [fluentd](https://github.com/fluent/fluentd), [PaperTrail](https://www.papertrail.com/), [cernan](https://github.com/postmates/cernan), [loki](https://grafana.com/oss/loki/), [Vector](https://vector.dev) |
+| b3m prober, vmprober | | [cloudprober](https://github.com/cloudprober/cloudprober), [prometheus/blackbox_exporter](https://www.github.com/prometheus/blackbox_exporter), [Checkly](https://www.checklyhq.com/) |
+
+
+### SRE/DevOps
+
 | Google Internal                 | Google External                          | Real-World                               |
 | ------------------------------- | ---------------------------------------- | ---------------------------------------- |
 | Assimilator                     |                                          | [Dominator](https://github.com/Cloud-Foundations/Dominator) |
-| Blaze                           | [Bazel](https://bazel.build)             | [Buck](https://buckbuild.com/), [Pants](https://www.pantsbuild.org/), [please.build](https://please.build/), [Blade](https://github.com/chen3feng/blade-build), [recc](https://gitlab.com/bloomberg/recc), [EngFlow](https://www.engflow.com/), [BuildBuddy](https://www.buildbuddy.io/), [flare.build](https://flare.build) |
-| Oncall                          |                                          | [PagerDuty](https://pagerduty.com), [OpsGenie](https://www.opsgenie.com/), [VictorOps](https://victorops.com/) |
-| varz/borgmon/monarch            | [Cloud Monitoring](https://cloud.google.com/monitoring) | [Datadog](https://www.datadoghq.com/), [Prometheus](https://prometheus.io), [M3](https://m3db.io/), [librato](https://www.librato.com), [newrelic](https://newrelic.com), skylight, scout, [Scotty](https://github.com/Cloud-Foundations/scotty)/[tricorder](https://github.com/Cloud-Foundations/tricorder), [netdata](https://github.com/netdata/netdata), [bosun](https://bosun.org/), also [this](https://vimeo.com/173610242) and [this](https://prometheus.io/docs/introduction/comparison/) |
-| Viceroy                         | Cloud Monitoring                         | [Grafana](https://grafana.com/) |
-| Exception/Error Tracking (thirdeye)   |                                          | Sentry.io, Raygun.io, [Rollbar](https://rollbar.com), Honeybadger, Airbrake, OverOps, [ELK stack](https://www.elastic.co/what-is/elk-stack) |
-| styleguides                     | [google styleguides](https://github.com/google/styleguide) | [PEP-8](https://www.python.org/dev/peps/pep-0008/), [HoundCI auto-style-reviewer](https://houndci.com/) |
-| Sponge                          |                                          | [EngFlow](https://www.engflow.com/) |
-| Blaze/Forge/TAP/BuildCop        | [Cloud Build](https://cloud.google.com/cloud-build/) | [buildkite](https://buildkite.com/), [CircleCI](https://circleci.com), [Drone](https://drone.io/), [EngFlow](https://www.engflow.com/), [github](https://github.blog/2019-08-08-github-actions-now-supports-ci-cd/), [gitlabCI](https://about.gitlab.com/product/continuous-integration/), [jenkins](https://jenkins.io/), [travis](https://travis-ci.org/) |
-| Forge/ObjFS                     |                                          | [EngFlow](https://www.engflow.com/), [flare.build](https://flare.build) |
-| Sandman(test env)/Guitar        |                                          |                   |
-| Sisyphus / Rapid                |                                          | [Spinnaker](https://www.spinnaker.io/), [lambdaCD](https://www.lambda.cd), screwdriver.cd, [CodeShip](https://codeship.com), [shipit-engine](https://github.com/Shopify/shipit-engine), [GoCD](https://www.gocd.org), [AWS CodeDeploy](https://aws.amazon.com/codedeploy/), [Capistrano](https://www.capistranorb.com), [Fabric](https://www.fabfile.org), [ConcourseCI](https://concourse.ci/), [samson](https://github.com/zendesk/samson) |
+| Oncall Pager, Lifeguard         |                                          | [PagerDuty](https://pagerduty.com), [OpsGenie](https://www.opsgenie.com/), [VictorOps](https://victorops.com/) |
+| OMG, IRM - Incident Management  | GCP Stackdriver IRM                      | [Incident.io](https://www.incident.io) , [FireHydrant](https://www.firehydrant.io) |
+| Sisyphus (rollouts) / Rapid     |                                          | [Spinnaker](https://www.spinnaker.io/), [lambdaCD](https://www.lambda.cd), screwdriver.cd, [CodeShip](https://codeship.com), [shipit-engine](https://github.com/Shopify/shipit-engine), [GoCD](https://www.gocd.org), [AWS CodeDeploy](https://aws.amazon.com/codedeploy/), [Capistrano](https://www.capistranorb.com), [Fabric](https://www.fabfile.org), [ConcourseCI](https://concourse.ci/), [samson](https://github.com/zendesk/samson) |
+| Sisyphus (workflow engine), Silkroads, GORE       |                                          | [Temporal](https://temporal.io/) |
 | MPM                             |                                          | [Docker](https://www.docker.com/), [OCI](https://opencontainers.org/) |
 | borgcfg / gcl, [Prodspec + Annealing](https://www.usenix.org/publications/loginonline/prodspec-and-annealing-intent-based-actuation-google-production)            | [Jsonnet](https://jsonnet.org/), [Cue](https://cuelang.org/) | [AWS Cloudformation](https://aws.amazon.com/cloudformation/), Puppet, Chef, Salt, Ansible, [Terraform](https://www.terraform.io), [kubecfg](https://github.com/kubecfg/kubecfg), [pulumi](https://github.com/pulumi/pulumi), [Nix](https://nix.dev/), [Pkl](https://pkl-lang.org/) |
-| logging, analog                 | [StackDriver](https://cloud.google.com/stackdriver/) | [logstash](https://github.com/elastic/logstash), [fluentd](https://github.com/fluent/fluentd), [PaperTrail](https://www.papertrail.com/), [cernan](https://github.com/postmates/cernan), [loki](https://grafana.com/oss/loki/) |
-| CodeSearch, Grimoire            | [Zoekt](https://github.com/google/zoekt) [kythe](https://github.com/kythe/kythe) [Code Search](https://developers.google.com/code-search/user/getting-started) (for Google open source code only, with separate UI for Android and Chromium. Go CLI [source](https://github.com/google/codesearch).) | [Sourcegraph](https://sourcegraph.com), [OpenGrok](https://github.com/OpenGrok/OpenGrok/), [livegrep](https://github.com/livegrep/livegrep) |
-| Critique, Gerrit, Mondrian etc. | [Gerrit](https://www.gerritcodereview.com/) | [Reviewable](https://reviewable.io) , [Phabricator](https://www.phacility.com/phabricator/)     |
-| cider                           |                                          | [Eclipse Che](https://www.eclipse.org/che/), [Cloud9](https://c9.io/), [gitpod.io](https://gitpod.io), [Coder](https://coder.com/), [Code-Server (VSCode in a Tab)](https://github.com/cdr/code-server), [DevZero](https://www.devzero.io/) |
 | buganizer                       | [Google Issue Tracker](https://issuetracker.google.com/) | [JIRA](https://www.atlassian.com/software/jira), [bugzilla](https://www.bugzilla.org/), github issues, [Linear](https://linear.app/) |
 | Bugjuggler                      |                                          | [SnoozeThis](https://www.snoozethis.com/) |
-| ToTT                            | [Google Test Blog](https://testing.googleblog.com/) | [Increment](https://increment.com/) |
 | Copybara / MOE                  | [Copybara](https://github.com/google/copybara), [MOE](https://github.com/google/MOE)  |                                          |
 | workflow/dependency management | | [Luigi](https://github.com/spotify/luigi), [Airflow](https://github.com/apache/airflow), [digdag](https://github.com/treasure-data/digdag), [Pachyderm](https://github.com/pachyderm/pachyderm), [Dask](https://github.com/dask/dask) |
 | ErrorProne                      | [ErrorProne](https://errorprone.info/)   | [SpotBugs](https://spotbugs.github.io/), [FindBugs](https://findbugs.sourceforge.net/) |
-| [Dapper](https://ai.google/research/pubs/pub36356) | [stackdriver trace](https://cloud.google.com/trace/) | [zipkin](https://github.com/openzipkin/zipkin), [OpenTelemetry](https://opentelemetry.io/), [jaeger](https://www.jaegertracing.io/), [LightStep](https://lightstep.com), [Honeycomb](https://www.honeycomb.io/trace/) |
-| C++ Tips of the Week            | [Abseil C++ Tips of the Week](https://abseil.io/tips/) |  |
-| [DiRT](https://cloud.google.com/blog/products/management-tools/shrinking-the-time-to-mitigate-production-incidents) | | [ChaosMonkey](https://github.com/Netflix/chaosmonkey), [aws fis](https://aws.amazon.com/fis/) |
-| [Rosie](https://cacm.acm.org/magazines/2016/7/204032-why-google-stores-billions-of-lines-of-code-in-a-single-repository/fulltext) | | [microplane](https://github.com/Clever/microplane), [silver-platter](https://github.com/jelmer/silver-platter) |
+| [DiRT](https://cloud.google.com/blog/products/management-tools/shrinking-the-time-to-mitigate-production-incidents), Catzilla | | [ChaosMonkey](https://github.com/Netflix/chaosmonkey), [aws fis](https://aws.amazon.com/fis/), [toxiproxy](https://github.com/Shopify/toxiproxy) |
 | API Improvements Proposals | [AIP](https://google.aip.dev/) | |
-| g4 {fix, submit} | | [Trunk.io](https://trunk.io), [Graphite](https://graphite.dev/) |
-| probers | | [cloudprober](https://github.com/cloudprober/cloudprober) |
 | GWP | [paper](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/36575.pdf) | [Parca](https://www.parca.dev), [Polar Signals](https://www.polarsignals.com) |
+
 
 ### Security
 | Google Internal                  | Google External | Open Source                              |
 | -------------------------------- | --------------- | ---------------------------------------- |
-| prodaccess/LOAS                  |                 | [Keymaster](https://github.com/Cloud-Foundations/keymaster) |
+| prodaccess/LOAS                  |                 | [Keymaster](https://github.com/Cloud-Foundations/keymaster) , [SmallStep](https://www.smallstep.com) (SaaS) |
 | prod secrets/identity management |                 | [chamber](https://github.com/segmentio/chamber), [knox](https://github.com/pinterest/knox), [SPIFFE](https://spiffe.io/) |
 
 ## IT / Operations / Misc
@@ -121,8 +138,8 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | stuff (SaaS IT management)               | [productiv](https://productiv.com/), [intello](https://www.intello.io/), [zylo](https://zylo.com/) |
 | stuff (Device Management)                | [jamf](https://www.jamf.com/) |
 | device security monitoring               | [Red Canary](https://redcanary.com/) |
-| beyondcorp | [beyondcorp](https://www.beyondcorp.com/) |
-| [go/ links](https://medium.com/@golinks/the-full-history-of-go-links-and-the-golink-system-cbc6d2c8bb3)                                | [golinks](https://www.golinks.io/), [go](https://github.com/kellegous/go), [Goat](https://goatcodes.com/), [trotto](https://github.com/trotto/go-links), [go-shorten](https://github.com/thomasdesr/go-shorten) |
+| beyondcorp | [beyondcorp](https://www.beyondcorp.com/) | [Tailscale](https://www.tailscale.org)
+| [go/ links](https://medium.com/@golinks/the-full-history-of-go-links-and-the-golink-system-cbc6d2c8bb3)                                | [golinks](https://www.golinks.io/), [go](https://github.com/kellegous/go), [Goat](https://goatcodes.com/), [trotto](https://github.com/trotto/go-links), [go-shorten](https://github.com/thomasdesr/go-shorten), [tailscale/golink](https://github.com/tailscale/golink) |
 | google3 philosophy                       | [innersource](https://resources.github.com/whitepapers/introduction-to-innersource/), [monorepo](https://cacm.acm.org/magazines/2016/7/204032-why-google-stores-billions-of-lines-of-code-in-a-single-repository/fulltext), [YouTube talk](https://www.youtube.com/watch?v=W71BTkUbdqE) |
 | doing code review                        | [code review](https://google.github.io/eng-practices/review/reviewer/) |
 | safely sharing 1-time secrets            | [sendsecure.ly](https://sendsecure.ly), [croc](https://github.com/schollz/croc), [onetimesecret](https://github.com/onetimesecret/onetimesecret), [privatebin](https://privatebin.info/) |


### PR DESCRIPTION
Refactors:
* Spin out Development/Buiild from the "DevOps" section
* Spin out SRE - Observability from the "DevOps" section
* Rename the "Devops" section to "SRE/DevOps", Xoogler SREs tend not to identify as DevOPs

Edits:
* Split GFE, Maglev, Uberproxy, since they are 3 different things
* Add GCP NEGs, Cilium and Metallb as Maglev/USPS equivalents
* Move Monarch from Services over to new Observability section
* Split Varz/Borgmon/Monarch into 3 entries, since they each have external equivalents
* Add toxiproxy under DiRT Catzilla
* Add Firebase Studio/IDX under Cider
* Add Sourcebot under Codesearch

Additions:
* Add OMG/IRM Equivalents for Incident Management
* Add Sisyphus, Silk Roads, Gore workflow , with reference to Temporal
* Add tailscale under BeyondCorp
* Add tailscale/golink under go links